### PR TITLE
Removed the testpackage linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,7 +22,6 @@ linters:
     - prealloc
     - predeclared
     - testifylint
-    - testpackage
     - unconvert
     - usestdlibvars
     - wsl


### PR DESCRIPTION
Accidentally, added that linter. In-package tests are far more popular approach in Golang community, so no need to move tests into a sep package.