### PR TITLE
Fail on no config passed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ vuln: install-checkers ## Check for vulnerabilities
 	@$(CHECKER_BIN)/gosec -quiet -exclude=G104 ./...
 
 run: ## Run Glide
-	@go run -ldflags $(LDFLAGS_COMMON) main.go
+	@go run -ldflags $(LDFLAGS_COMMON) main.go -c ./config.dev.yaml
 
 build: ## Build Glide
 	@go build -ldflags $(LDFLAGS_COMMON) -o ./dist/glide

--- a/config.dev.yaml
+++ b/config.dev.yaml
@@ -1,0 +1,8 @@
+telemetry:
+  logging:
+    level: debug  # debug, info, warn, error, fatal
+    encoding: console
+
+#api:
+#  http:
+#    ...

--- a/pkg/cmd/cli.go
+++ b/pkg/cmd/cli.go
@@ -34,6 +34,7 @@ func NewCLI() *cobra.Command {
 	}
 
 	cli.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "config file")
+	_ = cli.MarkPersistentFlagRequired("config")
 
 	return cli
 }

--- a/pkg/config/provider.go
+++ b/pkg/config/provider.go
@@ -25,7 +25,7 @@ func NewProvider() *Provider {
 func (p *Provider) Load(configPath string) (*Provider, error) {
 	content, err := os.ReadFile(filepath.Clean(configPath))
 	if err != nil {
-		return p, fmt.Errorf("unable to read the file %v: %w", configPath, err)
+		return p, fmt.Errorf("unable to read config file %v: %w", configPath, err)
 	}
 
 	// process raw config

--- a/pkg/config/provider_test.go
+++ b/pkg/config/provider_test.go
@@ -1,0 +1,20 @@
+package config
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestConfigProvider_NonExistingConfigFile(t *testing.T) {
+	_, err := NewProvider().Load("./testdata/doesntexist.yaml")
+
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "no such file or directory")
+}
+
+func TestConfigProvider_NonYAMLConfigFile(t *testing.T) {
+	_, err := NewProvider().Load("./testdata/provider.broken.yaml")
+
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "unable to parse config file")
+}

--- a/pkg/config/provider_test.go
+++ b/pkg/config/provider_test.go
@@ -1,8 +1,9 @@
 package config
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestConfigProvider_NonExistingConfigFile(t *testing.T) {

--- a/pkg/config/provider_test.go
+++ b/pkg/config/provider_test.go
@@ -3,19 +3,19 @@ package config
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestConfigProvider_NonExistingConfigFile(t *testing.T) {
 	_, err := NewProvider().Load("./testdata/doesntexist.yaml")
 
-	assert.Error(t, err)
-	assert.ErrorContains(t, err, "no such file or directory")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "no such file or directory")
 }
 
 func TestConfigProvider_NonYAMLConfigFile(t *testing.T) {
 	_, err := NewProvider().Load("./testdata/provider.broken.yaml")
 
-	assert.Error(t, err)
-	assert.ErrorContains(t, err, "unable to parse config file")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "unable to parse config file")
 }

--- a/pkg/config/testdata/provider.broken.yaml
+++ b/pkg/config/testdata/provider.broken.yaml
@@ -1,0 +1,6 @@
+{
+  "telemetry": {
+    "logging": {
+      "level": "debug",
+      "encoding": "console"
+


### PR DESCRIPTION
Handle a special case when the config flag is not passed. We fail in that case as we need to have at least one pool/model configured and we could not default that setup in some useful way.