### PR TITLE
Disable codecov/patch job

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,7 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 1%
+
+    patch: false


### PR DESCRIPTION
Disable `codecov/patch` job that forces to update code coverage for now.